### PR TITLE
Allow setting of user_name option in attendance command

### DIFF
--- a/README.org
+++ b/README.org
@@ -58,7 +58,8 @@
        Googling 'Creating a Google API Console project and client ID' would help.
        CLIENT_ID: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.apps.googleusercontent.com
        CLIENT_SECRET: xxxxxxxxxxxxxxxxxxxxxxxx
-
+       Gmail address: xxxxxxxxxxx@xxxxx.xxx
+       DEFAULT_SHEET_ID: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
        Making config directory ~/.config/sheetq ...
              create  /Users/nom/.config/sheetq
        Making cache directory ~/.cache/sheetq ...
@@ -80,7 +81,7 @@
 
   4) Check your sheet
      #+BEGIN_SRC sh
-       $ sheetq show '1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms' 'Class Data!A2:E'
+       $ sheetq show 'Class Data!A2:E'
 
        Alexandra,Female,4. Senior,CA,English
        Andrew,Male,1. Freshman,SD,Math

--- a/exe/sheetq
+++ b/exe/sheetq
@@ -95,17 +95,19 @@ class SheetqCLI < Clian::Cli
 
   expand_option :config
   option :sheet, :desc => "Set Google spreadsheet ID"
+  option :user_name, :desc => "Set attendee name"
   option :comment, :desc => "Set comment column"
 
   def attendance(inout)
     sheet_id = options[:sheet] || config.general.default_sheet_id
+    user_name = options[:user_name] || ENV["USER"]
     comment = options[:comment] || ""
     resource_class = Array # resource_class must implement to_a method
 
     spreadsheet = Sheetq::Service::Spreadsheet.new(client, sheet_id)
     sheet = Sheetq::Service::Sheet.new(spreadsheet, "attendance", Array)
     begin
-      sheet.append_row([Time.now.strftime("%Y-%m-%d %H:%M:%S"), inout, ENV["USER"], comment])
+      sheet.append_row([Time.now.strftime("%Y-%m-%d %H:%M:%S"), inout, user_name, comment])
     rescue => e
       puts "Error: #{e.message}"
     end

--- a/exe/sheetq
+++ b/exe/sheetq
@@ -138,11 +138,13 @@ class SheetqCLI < Clian::Cli
   ################################################################
   # Command: show
   ################################################################
-  desc "show SHEET_ID SHEET_NAME", "Show sheet"
+  desc "show SHEET_NAME", "Show sheet"
 
   expand_option :config
+  option :sheet, :desc => "Set Google spreadsheet ID"
 
-  def show(sheet_id, sheet_name)
+  def show(sheet_name)
+    sheet_id = options[:sheet] || config.general.default_sheet_id
     range = "#{sheet_name}"
     response = client.get_spreadsheet_values(sheet_id, range)
 

--- a/lib/sheetq/command/init.rb
+++ b/lib/sheetq/command/init.rb
@@ -23,6 +23,7 @@ module Sheetq
         config[:client_secret] = @shell.ask "CLIENT_SECRET:"
         config[:default_user] = @shell.ask "Gmail address:"
         config[:cache_directory] = "~/.cache/sheetq"
+        config[:default_sheet_id] = @shell.ask "DEFAULT_SHEET_ID:"
 
         # mkdir config_dir
         unless Dir.exist?(File.expand_path(config_dir))

--- a/lib/sheetq/templates/config.yml.erb
+++ b/lib/sheetq/templates/config.yml.erb
@@ -5,4 +5,5 @@ GENERAL:
   CLIENT_SECRET: "<%= config[:client_secret] %>"
   DEFAULT_USER: "<%= config[:default_user] %>"
   CACHE_DIRECTORY: "<%= config[:cache_directory] %>"
+  DEFAULT_SHEET_ID: "<%= config[:default_sheet_id] %>"
 # ZIP_PASSWORDS_FILE: "~/.config/glima/passwords.txt"


### PR DESCRIPTION
`attendance` コマンドに関して，出欠をとる人の名前をオプションでも入力できるように変更した．
また，`show`コマンドが他のコマンド(`attendance`，`nomnichi`，および `whois`) と求められる引数が異なっていたため，以下の変更も行った．
- デフォルトのスプレッドシートを指定できるようにするため，`init` コマンドの実行時に spreadsheet id を入力・決定できるように lib/sheetq/command/init.rb と lib/sheetq/templates/config.yml.erb を変更
- 上記に際して， `show` コマンドの引数から spreadsheet id を削除し，オプションとして入力できるように変更．また，README.org も変更