### PR TITLE
Make --format and --sheet options more generic

### DIFF
--- a/exe/sheetq
+++ b/exe/sheetq
@@ -46,7 +46,6 @@ class SheetqCLI < Clian::Cli
   ################################################################
   # register frequently used options
 
-  named_option :format,     :desc => "Set printing format", :enum => %w(short full metadata minimal raw mewl)
   named_option :dry_run,    :desc => "Perform a trial run with no changes made", :type => :boolean
   named_option :query,      :desc => "Filter messages by QUERY"
 
@@ -144,21 +143,30 @@ class SheetqCLI < Clian::Cli
 
   expand_option :config
   option :sheet, :desc => "Set Google spreadsheet ID"
+  option :format, :desc => "Set printing format", :enum => %w(csv json txt)
 
   def show(sheet_name)
     sheet_id = options[:sheet] || config.general.default_sheet_id
     range = "#{sheet_name}"
     response = client.get_spreadsheet_values(sheet_id, range)
 
-    max_length = response.values.map{|row| row.length}.max
-    last_index = [0, max_length - 1].max
+    # If header is in the form of: "氏名 (name)"
+    # take "name" as header instead of the whole string.
+    headers = response.values.first.map {|str|
+      if str =~ /\(([^)]+)\)$/ then $1 else str end
+    }
+    rows = response.values[1..-1]
 
-    response.values.each do |row|
-      if row.length < max_length
-        row[last_index] = nil
-      end
-      puts row.join(",")
-    end
+    printable = case options[:format]
+                when 'csv'
+                  array_to_csv(headers, rows)
+                when 'json'
+                  array_to_json(headers, rows)
+                else
+                  array_to_text(headers, rows)
+                end
+
+    puts printable
   end
 
 
@@ -166,6 +174,24 @@ class SheetqCLI < Clian::Cli
   # private
 
   private
+
+  def array_to_csv(headers, rows)
+    require 'csv'
+    return CSV.generate(headers: headers, write_headers: true) do |csv|
+      rows.each do |row|
+        csv.add_row row
+      end
+    end
+  end
+
+  def array_to_json(headers, rows)
+    rows.map {|row| Hash[headers.zip(row)]}.to_json
+  end
+
+  def array_to_text(headers, rows)
+    headers.join(' ') + "\n" +
+      rows.map {|row| row.join(" ")}.join("\n")
+  end
 
   def error_and_exit(message)
     STDERR.puts message

--- a/exe/sheetq
+++ b/exe/sheetq
@@ -48,6 +48,7 @@ class SheetqCLI < Clian::Cli
 
   named_option :dry_run,    :desc => "Perform a trial run with no changes made", :type => :boolean
   named_option :query,      :desc => "Filter messages by QUERY"
+  named_option :sheet,      :desc => "Set Google spreadsheet ID"
 
   ################################################################
   # Command: auth
@@ -78,12 +79,14 @@ class SheetqCLI < Clian::Cli
   ################################################################
   # Command: nomnichi
   ################################################################
-  desc "nomnichi [SHEET_ID]", "Show recently published nomnichi articles"
+  desc "nomnichi", "Show recently published nomnichi articles"
 
   expand_option :config
+  expand_option :sheet
   option :whosnext, :type => :boolean, :desc => "Show the next candidate for writing nomnichi article"
 
-  def nomnichi(member_sheet_id = config.general.default_sheet_id)
+  def nomnichi
+    member_sheet_id = options[:sheet] || config.general.default_sheet_id
     Sheetq::Command::Nomnichi.new(member_sheet_id, options[:whosnext])
   end
 
@@ -93,7 +96,7 @@ class SheetqCLI < Clian::Cli
   desc "attendance INOUT", "Logger to 'attendance' sheet"
 
   expand_option :config
-  option :sheet, :desc => "Set Google spreadsheet ID"
+  expand_option :sheet
   option :user_name, :desc => "Set attendee name"
   option :comment, :desc => "Set comment column"
 
@@ -118,7 +121,7 @@ class SheetqCLI < Clian::Cli
   desc "whois KEYWORD", "Search members' profile by KEYWORD"
 
   expand_option :config
-  option :sheet, :desc => "Set Google spreadsheet ID"
+  expand_option :sheet
 
   def whois(keyword)
     member_sheet_id = options[:sheet] || config.general.default_sheet_id
@@ -139,15 +142,15 @@ class SheetqCLI < Clian::Cli
   ################################################################
   # Command: show
   ################################################################
-  desc "show SHEET_NAME", "Show sheet"
+  desc "show SHEET_NAME", "Show sheet in various formats"
 
   expand_option :config
-  option :sheet, :desc => "Set Google spreadsheet ID"
+  expand_option :sheet
   option :format, :desc => "Set printing format", :enum => %w(csv json txt)
 
   def show(sheet_name)
-    sheet_id = options[:sheet] || config.general.default_sheet_id
     range = "#{sheet_name}"
+    sheet_id = options[:sheet] || config.general.default_sheet_id
     response = client.get_spreadsheet_values(sheet_id, range)
 
     # If header is in the form of: "氏名 (name)"


### PR DESCRIPTION
1. Make SHEET_ID argument non-mandatory
   All commands that require sheet_id are modified to take default sheet id from config.yml.
   To set a specific sheet_id, use --sheet option.
2. Add --format option to show command
   json, csv, and txt are available
